### PR TITLE
Fixes for debug logging failures

### DIFF
--- a/internal-layered-architecture/explicit-proxy/sslo-layering-exp-rule
+++ b/internal-layered-architecture/explicit-proxy/sslo-layering-exp-rule
@@ -1,10 +1,10 @@
 ## SSL Orchestrator Use Case: Internal Layered Architecture - Client-Facing Switching iRule
-## Version: 2.0
-## Date: 2020-11-30
+## Version: 2.1
+## Date: 2024-10-18
 ## Author: Kevin Stewart, F5 Networks
 ## Configuration: see SSLOLIBEXP iRule for build instructions
 
-## Set a default topology assuming no other matches (d not edit)
+## Set a default topology assuming no other matches (do not edit)
 when CLIENT_ACCEPTED {
     call SSLOLIBEXP::target $static::default_topology
 }
@@ -15,7 +15,7 @@ when CLIENT_ACCEPTED {
 #####################################################
 when RULE_INIT {
     ## User-defined: DEBUG logging flag (1=on, 0=off)
-    set static::SSLODEBUGEXP 1
+    set static::SSLODEBUGEXP 0
 
     ## User-defined: Default topology if no rules match (the topology name as defined in SSLO)
     set static::default_topology "interceptexp"
@@ -30,8 +30,8 @@ when HTTP_PROXY_REQUEST {
     ## disable proxy to create pass-through
     HTTP::proxy disable
     
-    ## set local host variable (for logging)
-    set host ""
+    ## Do not edit - create host variable and set based on HTTP request (for logging)
+    set host ""; call SSLOLIBEXP::HOST ""
     
     ## Standard certificate Pinners bypassexp rule (specify your bypassexp topology)
     if { [call SSLOLIBEXP::HOST CAT:/Common/sslo-urlCatPinners] } { call SSLOLIBEXP::target "bypassexp" ${host} "pinners" ; return}

--- a/internal-layered-architecture/transparent-proxy/sslo-layering-rule
+++ b/internal-layered-architecture/transparent-proxy/sslo-layering-rule
@@ -1,10 +1,10 @@
 ## SSL Orchestrator Use Case: Internal Layered Architecture - Client-Facing Switching iRule
-## Version: 2.2
-## Date: 2021-07-19
+## Version: 2.3
+## Date: 2024-10-18
 ## Author: Kevin Stewart, F5 Networks
 ## Configuration: see SSLOLIB iRule for build instructions
 
-## Set a default topology assuming no other matches (d not edit)
+## Set a default topology assuming no other matches (do not edit)
 when CLIENT_ACCEPTED {
     call SSLOLIB::target $static::default_topology
 }
@@ -30,8 +30,8 @@ when CLIENTSSL_CLIENTHELLO {
     ## Do not edit
     set cmd "catch { HTTP::disable }" ; eval ${cmd}
     
-    ## Set local sni variable (for logging)
-    set sni ""
+    ## Do not edit - create sni variable and set from TLS client hello (for logging)
+    set sni ""; call SSLOLIB::SNI ""
 
     ## Standard certificate Pinners bypass rule (specify your bypass topology)
     if { [call SSLOLIB::SNI CAT:/Common/sslo-urlCatPinners] } { call SSLOLIB::target "bypass" ${sni} "pinners" ; return}


### PR DESCRIPTION
This pull request addresses a failure to debug log when rules that do not use invoke the HOST (explicit) or SNI (transparent) matching conditions (procs) are placed above rules that do use the aforementioned matching conditions (procs).

Calling the HOST (explicit) or SNI (transparent) proc will execute logic that sets the host (explicit) or sni (transparent) variable based on the HTTP request / TLS client hello. If debug logging is enabled and a non-HOST/SNI rule matches traffic before either the HOST or SNI proc is called, the host/sni variable will remain as null, and will always fail the log if condition in the "target" proc.